### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.8](https://github.com/near-cli-rs/interactive-clap/compare/interactive-clap-v0.2.7...interactive-clap-v0.2.8) - 2024-01-15
+
+### Added
+- Added possibility to process optional fields ([#13](https://github.com/near-cli-rs/interactive-clap/pull/13))
+
 ## [0.2.7](https://github.com/near-cli-rs/interactive-clap/compare/interactive-clap-v0.2.6...interactive-clap-v0.2.7) - 2023-10-13
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = [
 
 [package]
 name = "interactive-clap"
-version = "0.2.7"
+version = "0.2.8"
 authors = ["FroVolod <frol_off@meta.ua>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -15,7 +15,7 @@ description = "Interactive mode extension crate to Command Line Arguments Parser
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-interactive-clap-derive = { path = "interactive-clap-derive", version = "0.2.7" }
+interactive-clap-derive = { path = "interactive-clap-derive", version = "0.2.8" }
 strum = { version = "0.24", features = ["derive"] }
 strum_macros = "0.24"
 

--- a/interactive-clap-derive/CHANGELOG.md
+++ b/interactive-clap-derive/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.8](https://github.com/near-cli-rs/interactive-clap/compare/interactive-clap-derive-v0.2.7...interactive-clap-derive-v0.2.8) - 2024-01-15
+
+### Added
+- Added possibility to process optional fields ([#13](https://github.com/near-cli-rs/interactive-clap/pull/13))
+
 ## [0.2.7](https://github.com/near-cli-rs/interactive-clap/compare/interactive-clap-derive-v0.2.6...interactive-clap-derive-v0.2.7) - 2023-10-13
 
 ### Added

--- a/interactive-clap-derive/Cargo.toml
+++ b/interactive-clap-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "interactive-clap-derive"
-version = "0.2.7"
+version = "0.2.8"
 authors = ["FroVolod <frol_off@meta.ua>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## 🤖 New release
* `interactive-clap-derive`: 0.2.7 -> 0.2.8
* `interactive-clap`: 0.2.7 -> 0.2.8 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `interactive-clap-derive`
<blockquote>

## [0.2.8](https://github.com/near-cli-rs/interactive-clap/compare/interactive-clap-derive-v0.2.7...interactive-clap-derive-v0.2.8) - 2024-01-15

### Added
- Added possibility to process optional fields ([#13](https://github.com/near-cli-rs/interactive-clap/pull/13))
</blockquote>

## `interactive-clap`
<blockquote>

## [0.2.8](https://github.com/near-cli-rs/interactive-clap/compare/interactive-clap-v0.2.7...interactive-clap-v0.2.8) - 2024-01-15

### Added
- Added possibility to process optional fields ([#13](https://github.com/near-cli-rs/interactive-clap/pull/13))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).