### PR TITLE
Don't split arguments in `try_parse_from`

### DIFF
--- a/interactive-clap-derive/Cargo.toml
+++ b/interactive-clap-derive/Cargo.toml
@@ -22,3 +22,6 @@ syn = "1"
 prettyplease = "0.1"
 insta = "1"
 syn = { version = "1", features = ["full"] }
+
+[features]
+try-parse-from = []

--- a/interactive-clap-derive/Cargo.toml
+++ b/interactive-clap-derive/Cargo.toml
@@ -22,6 +22,3 @@ syn = "1"
 prettyplease = "0.1"
 insta = "1"
 syn = { version = "1", features = ["full"] }
-
-[features]
-try-parse-from = []

--- a/interactive-clap-derive/src/derives/interactive_clap/mod.rs
+++ b/interactive-clap-derive/src/derives/interactive_clap/mod.rs
@@ -174,14 +174,21 @@ pub fn impl_interactive_clap(ast: &syn::DeriveInput) -> TokenStream {
                 .unwrap_or(quote!());
 
             let fn_try_parse_from = if cfg!(feature = "try-parse-from") {
-                Some(quote! {
+                quote! {
                     pub fn try_parse_from(s: &str) -> Result<#cli_name, clap::Error> {
                         <#cli_name as clap::Parser>::try_parse_from(::shell_words::split(s)
                             .map_err(|_| ::clap::Error::raw(::clap::error::ErrorKind::InvalidSubcommand, "missing closing quote"))?)
                     }
-                })
+                }
             } else {
-                None
+                quote! {
+                    #[deprecated(
+                        note = "This method does not handle quoted arguments correctly. Add `try-parse-from` feature to `interactive-clap-derive` and add `shell-words` dependency to enable the correct implementation."
+                    )]
+                    pub fn try_parse_from(s: &str) -> Result<#cli_name, clap::Error> {
+                        <#cli_name as clap::Parser>::try_parse_from(s.split(' '))
+                    }
+                }
             };
 
             quote! {
@@ -314,14 +321,21 @@ pub fn impl_interactive_clap(ast: &syn::DeriveInput) -> TokenStream {
                 self::methods::from_cli_for_enum::from_cli_for_enum(ast, variants);
 
             let fn_try_parse_from = if cfg!(feature = "try-parse-from") {
-                Some(quote! {
+                quote! {
                     pub fn try_parse_from(s: &str) -> Result<#cli_name, clap::Error> {
                         <#cli_name as clap::Parser>::try_parse_from(::shell_words::split(s)
                             .map_err(|_| ::clap::Error::raw(::clap::error::ErrorKind::InvalidSubcommand, "missing closing quote"))?)
                     }
-                })
+                }
             } else {
-                None
+                quote! {
+                    #[deprecated(
+                        note = "This method does not handle quoted arguments correctly. Add `try-parse-from` feature to `interactive-clap-derive` and add `shell-words` dependency to enable the correct implementation."
+                    )]
+                    pub fn try_parse_from(s: &str) -> Result<#cli_name, clap::Error> {
+                        <#cli_name as clap::Parser>::try_parse_from(s.split(' '))
+                    }
+                }
             };
 
             quote! {

--- a/interactive-clap-derive/src/derives/interactive_clap/mod.rs
+++ b/interactive-clap-derive/src/derives/interactive_clap/mod.rs
@@ -173,6 +173,17 @@ pub fn impl_interactive_clap(ast: &syn::DeriveInput) -> TokenStream {
                 })
                 .unwrap_or(quote!());
 
+            let fn_try_parse_from = if cfg!(feature = "try-parse-from") {
+                Some(quote! {
+                    pub fn try_parse_from(s: &str) -> Result<#cli_name, clap::Error> {
+                        <#cli_name as clap::Parser>::try_parse_from(::shell_words::split(s)
+                            .map_err(|_| ::clap::Error::raw(::clap::error::ErrorKind::InvalidSubcommand, "missing closing quote"))?)
+                    }
+                })
+            } else {
+                None
+            };
+
             quote! {
                 #[derive(Debug, Default, Clone, clap::Parser, interactive_clap::ToCliArgs)]
                 #[clap(author, version, about, long_about = None)]
@@ -199,9 +210,7 @@ pub fn impl_interactive_clap(ast: &syn::DeriveInput) -> TokenStream {
                         <#cli_name as clap::Parser>::parse()
                     }
 
-                    pub fn try_parse_from(s: &str) -> Result<#cli_name, clap::Error> {
-                        <#cli_name as clap::Parser>::try_parse_from(s.split(" "))
-                    }
+                    #fn_try_parse_from
                 }
 
                 impl From<#name> for #cli_name {
@@ -304,6 +313,17 @@ pub fn impl_interactive_clap(ast: &syn::DeriveInput) -> TokenStream {
             let fn_from_cli_for_enum =
                 self::methods::from_cli_for_enum::from_cli_for_enum(ast, variants);
 
+            let fn_try_parse_from = if cfg!(feature = "try-parse-from") {
+                Some(quote! {
+                    pub fn try_parse_from(s: &str) -> Result<#cli_name, clap::Error> {
+                        <#cli_name as clap::Parser>::try_parse_from(::shell_words::split(s)
+                            .map_err(|_| ::clap::Error::raw(::clap::error::ErrorKind::InvalidSubcommand, "missing closing quote"))?)
+                    }
+                })
+            } else {
+                None
+            };
+
             quote! {
                 #[derive(Debug, Clone, clap::Parser, interactive_clap::ToCliArgs)]
                 pub enum #cli_name {
@@ -337,9 +357,7 @@ pub fn impl_interactive_clap(ast: &syn::DeriveInput) -> TokenStream {
                         <#cli_name as clap::Parser>::parse()
                     }
 
-                    pub fn try_parse_from(s: &str) -> Result<#cli_name, clap::Error> {
-                        <#cli_name as clap::Parser>::try_parse_from(s.split(" "))
-                    }
+                    #fn_try_parse_from
                 }
             }
         }

--- a/interactive-clap-derive/src/tests/snapshots/interactive_clap_derive__tests__test_simple_struct__flag.snap
+++ b/interactive-clap-derive/src/tests/snapshots/interactive_clap_derive__tests__test_simple_struct__flag.snap
@@ -30,7 +30,7 @@ impl interactive_clap::FromCli for Args {
     where
         Self: Sized + interactive_clap::ToCli,
     {
-        let mut clap_variant = optional_clap_variant.unwrap_or_default();
+        let mut clap_variant = optional_clap_variant.clone().unwrap_or_default();
         let offline = clap_variant.offline.clone();
         let new_context_scope = InteractiveClapContextScopeForArgs {
             offline: offline.into(),
@@ -49,11 +49,14 @@ impl Args {
             Err(err) => Err(err.into()),
         }
     }
-    fn try_parse() -> Result<CliArgs, clap::Error> {
+    pub fn try_parse() -> Result<CliArgs, clap::Error> {
         <CliArgs as clap::Parser>::try_parse()
     }
-    fn parse() -> CliArgs {
+    pub fn parse() -> CliArgs {
         <CliArgs as clap::Parser>::parse()
+    }
+    pub fn try_parse_from(s: &str) -> Result<CliArgs, clap::Error> {
+        <CliArgs as clap::Parser>::try_parse_from(s.split(" "))
     }
 }
 impl From<Args> for CliArgs {
@@ -63,4 +66,3 @@ impl From<Args> for CliArgs {
         }
     }
 }
-

--- a/interactive-clap-derive/src/tests/snapshots/interactive_clap_derive__tests__test_simple_struct__flag.snap
+++ b/interactive-clap-derive/src/tests/snapshots/interactive_clap_derive__tests__test_simple_struct__flag.snap
@@ -56,7 +56,13 @@ impl Args {
         <CliArgs as clap::Parser>::parse()
     }
     pub fn try_parse_from(s: &str) -> Result<CliArgs, clap::Error> {
-        <CliArgs as clap::Parser>::try_parse_from(s.split(" "))
+        <CliArgs as clap::Parser>::try_parse_from(
+            ::shell_words::split(s)
+                .map_err(|_| ::clap::Error::raw(
+                    ::clap::error::ErrorKind::InvalidSubcommand,
+                    "missing closing quote",
+                ))?,
+        )
     }
 }
 impl From<Args> for CliArgs {

--- a/interactive-clap-derive/src/tests/snapshots/interactive_clap_derive__tests__test_simple_struct__flag.snap
+++ b/interactive-clap-derive/src/tests/snapshots/interactive_clap_derive__tests__test_simple_struct__flag.snap
@@ -55,14 +55,12 @@ impl Args {
     pub fn parse() -> CliArgs {
         <CliArgs as clap::Parser>::parse()
     }
-    pub fn try_parse_from(s: &str) -> Result<CliArgs, clap::Error> {
-        <CliArgs as clap::Parser>::try_parse_from(
-            ::shell_words::split(s)
-                .map_err(|_| ::clap::Error::raw(
-                    ::clap::error::ErrorKind::InvalidSubcommand,
-                    "missing closing quote",
-                ))?,
-        )
+    pub fn try_parse_from<I, T>(itr: I) -> Result<CliArgs, clap::Error>
+    where
+        I: ::std::iter::IntoIterator<Item = T>,
+        T: ::std::convert::Into<::std::ffi::OsString> + ::std::clone::Clone,
+    {
+        <CliArgs as clap::Parser>::try_parse_from(itr)
     }
 }
 impl From<Args> for CliArgs {

--- a/interactive-clap-derive/src/tests/snapshots/interactive_clap_derive__tests__test_simple_struct__simple_struct.snap
+++ b/interactive-clap-derive/src/tests/snapshots/interactive_clap_derive__tests__test_simple_struct__simple_struct.snap
@@ -33,7 +33,7 @@ impl interactive_clap::FromCli for Args {
     where
         Self: Sized + interactive_clap::ToCli,
     {
-        let mut clap_variant = optional_clap_variant.unwrap_or_default();
+        let mut clap_variant = optional_clap_variant.clone().unwrap_or_default();
         if clap_variant.age.is_none() {
             clap_variant
                 .age = match Self::input_age(&context) {
@@ -112,11 +112,14 @@ impl Args {
             Err(err) => Err(err.into()),
         }
     }
-    fn try_parse() -> Result<CliArgs, clap::Error> {
+    pub fn try_parse() -> Result<CliArgs, clap::Error> {
         <CliArgs as clap::Parser>::try_parse()
     }
-    fn parse() -> CliArgs {
+    pub fn parse() -> CliArgs {
         <CliArgs as clap::Parser>::parse()
+    }
+    pub fn try_parse_from(s: &str) -> Result<CliArgs, clap::Error> {
+        <CliArgs as clap::Parser>::try_parse_from(s.split(" "))
     }
 }
 impl From<Args> for CliArgs {
@@ -128,4 +131,3 @@ impl From<Args> for CliArgs {
         }
     }
 }
-

--- a/interactive-clap-derive/src/tests/snapshots/interactive_clap_derive__tests__test_simple_struct__simple_struct.snap
+++ b/interactive-clap-derive/src/tests/snapshots/interactive_clap_derive__tests__test_simple_struct__simple_struct.snap
@@ -118,14 +118,12 @@ impl Args {
     pub fn parse() -> CliArgs {
         <CliArgs as clap::Parser>::parse()
     }
-    pub fn try_parse_from(s: &str) -> Result<CliArgs, clap::Error> {
-        <CliArgs as clap::Parser>::try_parse_from(
-            ::shell_words::split(s)
-                .map_err(|_| ::clap::Error::raw(
-                    ::clap::error::ErrorKind::InvalidSubcommand,
-                    "missing closing quote",
-                ))?,
-        )
+    pub fn try_parse_from<I, T>(itr: I) -> Result<CliArgs, clap::Error>
+    where
+        I: ::std::iter::IntoIterator<Item = T>,
+        T: ::std::convert::Into<::std::ffi::OsString> + ::std::clone::Clone,
+    {
+        <CliArgs as clap::Parser>::try_parse_from(itr)
     }
 }
 impl From<Args> for CliArgs {

--- a/interactive-clap-derive/src/tests/snapshots/interactive_clap_derive__tests__test_simple_struct__simple_struct.snap
+++ b/interactive-clap-derive/src/tests/snapshots/interactive_clap_derive__tests__test_simple_struct__simple_struct.snap
@@ -119,7 +119,13 @@ impl Args {
         <CliArgs as clap::Parser>::parse()
     }
     pub fn try_parse_from(s: &str) -> Result<CliArgs, clap::Error> {
-        <CliArgs as clap::Parser>::try_parse_from(s.split(" "))
+        <CliArgs as clap::Parser>::try_parse_from(
+            ::shell_words::split(s)
+                .map_err(|_| ::clap::Error::raw(
+                    ::clap::error::ErrorKind::InvalidSubcommand,
+                    "missing closing quote",
+                ))?,
+        )
     }
 }
 impl From<Args> for CliArgs {


### PR DESCRIPTION
`try_parse_from` doesn't have special treatment for quotes (`command "some thing"` is split into 3 arguments).

This PR introduces a new `interactive-clap-derive` crate feature `try-parse-from`, so that existing codebases don't need to add `shell-words` dependency if they don't use it. If this feature is disabled, this function reverts to the old behavior with a deprecation warning.