### PR TITLE
chore: release v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2](https://github.com/near-cli-rs/interactive-clap/compare/interactive-clap-v0.3.1...interactive-clap-v0.3.2) - 2025-02-11
+
+### Added
+
+- propagate doc comments on flags and arguments to `--help/-h` + structs derive refactor (#26)
+
+### Other
+
+- Added "cargo test" command (#33)
+- Added clippy to examples (#31)
+- Added code style check (#29)
+- add CODEOWNERS (#27)
+- Added a demo image to README (#24)
+
 ## [0.3.1](https://github.com/near-cli-rs/interactive-clap/compare/interactive-clap-v0.3.0...interactive-clap-v0.3.1) - 2024-09-18
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = [
 
 [package]
 name = "interactive-clap"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["FroVolod <frol_off@meta.ua>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -15,7 +15,7 @@ description = "Interactive mode extension crate to Command Line Arguments Parser
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-interactive-clap-derive = { path = "interactive-clap-derive", version = "0.3.1" }
+interactive-clap-derive = { path = "interactive-clap-derive", version = "0.3.2" }
 strum = { version = "0.24", features = ["derive"] }
 strum_macros = "0.24"
 

--- a/interactive-clap-derive/CHANGELOG.md
+++ b/interactive-clap-derive/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2](https://github.com/near-cli-rs/interactive-clap/compare/interactive-clap-derive-v0.3.1...interactive-clap-derive-v0.3.2) - 2025-02-11
+
+### Added
+
+- propagate doc comments on flags and arguments to `--help/-h` + structs derive refactor (#26)
+
+### Other
+
+- Added code style check (#29)
+
 ## [0.3.1](https://github.com/near-cli-rs/interactive-clap/compare/interactive-clap-derive-v0.3.0...interactive-clap-derive-v0.3.1) - 2024-09-18
 
 ### Added

--- a/interactive-clap-derive/Cargo.toml
+++ b/interactive-clap-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "interactive-clap-derive"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["FroVolod <frol_off@meta.ua>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `interactive-clap-derive`: 0.3.1 -> 0.3.2
* `interactive-clap`: 0.3.1 -> 0.3.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `interactive-clap-derive`

<blockquote>

## [0.3.2](https://github.com/near-cli-rs/interactive-clap/compare/interactive-clap-derive-v0.3.1...interactive-clap-derive-v0.3.2) - 2025-02-11

### Added

- propagate doc comments on flags and arguments to `--help/-h` + structs derive refactor (#26)

### Other

- Added code style check (#29)
</blockquote>

## `interactive-clap`

<blockquote>

## [0.3.2](https://github.com/near-cli-rs/interactive-clap/compare/interactive-clap-v0.3.1...interactive-clap-v0.3.2) - 2025-02-11

### Added

- propagate doc comments on flags and arguments to `--help/-h` + structs derive refactor (#26)

### Other

- Added "cargo test" command (#33)
- Added clippy to examples (#31)
- Added code style check (#29)
- add CODEOWNERS (#27)
- Added a demo image to README (#24)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).